### PR TITLE
Always set index param in snapshot for complex postgres types

### DIFF
--- a/peewee_migrations/migrator.py
+++ b/peewee_migrations/migrator.py
@@ -8,9 +8,15 @@ from datetime import datetime, date, time
 from collections import OrderedDict, namedtuple
 
 try:
-    from playhouse.postgres_ext import ArrayField as PgArrayField
+    from playhouse.postgres_ext import (
+        ArrayField as PgArrayField,
+        HStoreField as PgHStoreField,
+        BinaryJSONField as PgBinaryJSONField,
+        TSVectorField as PgTSVectorField,
+    )
+
 except ImportError:
-    PgArrayField = None
+    PgArrayField = PgHStoreField = PgBinaryJSONField = PgTSVectorField = None
 
 
 __all__ = ('Router', 'Snapshot', 'Migrator', 'MigrationError', 'deconstructor')
@@ -215,6 +221,24 @@ if PgArrayField:
         params['dimensions'] = field.dimensions
         params['convert_values'] = field.convert_values
         params['field_class'] = field._ArrayField__field.__class__
+
+
+if PgHStoreField:
+    @deconstructor(PgHStoreField)
+    def hstorefield_deconstructor(field, params, **_):
+        params['index'] = field.index
+
+
+if PgBinaryJSONField:
+    @deconstructor(PgBinaryJSONField)
+    def binaryjsonfield_deconstructor(field, params, **_):
+        params['index'] = field.index
+
+
+if PgTSVectorField:
+    @deconstructor(PgTSVectorField)
+    def tsvectorfield_deconstructor(field, params, **_):
+        params['index'] = field.index
 
 
 @deconstructor(peewee.ForeignKeyField)


### PR DESCRIPTION
HStoreField, BinaryJSONField and TSVectorField have index turned on by
default by peewee. Now it is always explicitly set.