### PR TITLE
Add defer initialization option

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,11 +161,23 @@ For more information on using the commands see --help.
 ```
 {
   "prerun": "some code here",  // some code to run before executing any command
+  "init": "some code here",    // some database initialization code in case of defer initialization
   "directory": "migrations",   // folder to hold migrations
   "history": "migratehistory", // table to hold migration history
   "models": [                  // list of models to watch
     "module1.Model1",
     "module2.Model2"
   ]
+}
+```
+
+### Run-time database configuration
+
+In case of using defer initialization (like `PostgresqlDatabase(None)`) database might be initialized using `init` section.
+To make it a little bit easier `db` and `getenv` objects are available in the code scope.
+Example code using environment variables:
+```
+{
+  "init": "db.init(getenv('DB_NAME'), user=getenv('DB_USER'), password=getenv('DB_PASSWORD', host=getenv('DB_HOST'))"
 }
 ```

--- a/peewee_migrations/cli.py
+++ b/peewee_migrations/cli.py
@@ -40,6 +40,7 @@ def init_config(filename):
     with open(filename, 'wt') as f:
         data = {
             'prerun': '# some code here',
+            'init': '# some db initialization code here',
             'directory': 'migrations',
             'history': 'migratehistory',
             'models': []
@@ -205,6 +206,13 @@ def load_conf(ctx):
         sys.exit(3)
 
     conf['db'] = databases.pop()
+
+    if conf.get('init'):
+        if isinstance(conf['init'], list):
+            init_run = '\n'.join(conf['init'])
+        else:
+            init_run = conf['init']
+        exec(init_run, {'getenv': os.getenv, 'db': conf['db']})
 
     return conf
 


### PR DESCRIPTION
Just came across problem when try to use `pem` with my code that uses runtime database configuration:
```
$ pem list

Traceback (most recent call last):
  File "/home/user/.virtualenvs/project/lib/python3.9/site-packages/peewee.py", line 3142, in execute_sql
    cursor = self.cursor(commit)
  File "/home/user/.virtualenvs/project/lib/python3.9/site-packages/peewee.py", line 3126, in cursor
    self.connect()
  File "/home/user/.virtualenvs/project/lib/python3.9/site-packages/peewee.py", line 3071, in connect
    raise InterfaceError('Error, database must be initialized '
peewee.InterfaceError: Error, database must be initialized before opening a connection.
...
```

This is my quick solution for this - adding `init` section to initialize such Peewee's database objects.